### PR TITLE
Avoid mutating local copy of feature branch on merge

### DIFF
--- a/git-mergepr
+++ b/git-mergepr
@@ -29,21 +29,22 @@ if [ $? != 0 ]; then
 	exit 2
 fi
 
-CHECKOUT_OUTPUT="$(git checkout -q $DESTINATION_BRANCH)"
+CHECKOUT_OUTPUT="$(git checkout -q --detach origin/$DESTINATION_BRANCH)"
 if [ $? != 0 ]; then
 	echo "ERROR:"
 	echo "$CHECKOUT_OUTPUT"
 	exit 3
 fi
 
-MERGE_OUTPUT="$(git merge -S --verify-signatures --no-ff origin/$BRANCH_TO_MERGE)"
+MERGE_MESSAGE="Merge remote-tracking branch 'origin/$BRANCH_TO_MERGE' into $DESTINATION_BRANCH"
+MERGE_OUTPUT=$(git merge -S --verify-signatures --no-ff -m "$MERGE_MESSAGE" origin/$BRANCH_TO_MERGE)
 if [ $? != 0 ]; then
 	echo "ERROR:"
 	echo "$MERGE_OUTPUT"
 	exit 4
 fi
 
-PUSH_OUTPUT="$(git push -q origin $DESTINATION_BRANCH)"
+PUSH_OUTPUT="$(git push -q origin HEAD:$DESTINATION_BRANCH)"
 if [ $? != 0 ]; then
 	echo "ERROR:"
 	echo "$PUSH_OUTPUT"


### PR DESCRIPTION
Prior to this commit, if somebody attempted to merge a feature branch into
an upstream repo from their local repository using git-mergepr, and they
had a local version of the branch to be merged that differed from the remote
version, their local branch would be mutated. This commit checks out the branch
top be mergeed in a detached state, so that the process leaves the developer's
local copy of the feature branch untouched.

Closes #4.