### PR TITLE
Update README w pyhamcrest

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ In order to run the tests, you'll need behave, which in turn relies upon python.
 
 ```
 $ apt install gnupg2 git python python-pip
-$ pip install behave
+$ pip install behave pyhamcrest
 
 ```
 


### PR DESCRIPTION
Prior to this commit, the README instructions were missing a step for installing pyhamcrest, which is one of the test dependencies. This commit updates the README to reflect that.