### PR TITLE
Revert "Merge remote-tracking branch 'origin/maint/code-cleanup' into devel

### DIFF
--- a/git-mergepr
+++ b/git-mergepr
@@ -1,47 +1,85 @@
 #!/bin/bash
 
-prune_flag=off
-src_branch=""
-dest_branch=""
+PRUNE_FLAG=off
+BRANCH_TO_MERGE=""
+DESTINATION_BRANCH=""
 
 if [ "$1" = "--no-prune" ]; then
-	prune_flag=on
-	src_branch="$2"
-	dest_branch="$3"
+	PRUNE_FLAG=on
+	BRANCH_TO_MERGE="$2"
+	DESTINATION_BRANCH="$3"
 else
-	src_branch="$1"
-	dest_branch="$2"
+	BRANCH_TO_MERGE="$1"
+	DESTINATION_BRANCH="$2"
 fi
 
-function exit_with_err() {
-	echo "Error performing operation. Exiting."
-	if [ $1 ]; then
-		exit $1
-	else
-		exit 1
+CURRENT_BRANCH="$(git symbolic-ref --short HEAD)"
+
+STASH_OUTPUT="$(git stash save)"
+if [ $? != 0 ]; then
+	echo "ERROR:"
+	echo "$STASH_OUTPUT"
+	exit 1
+fi
+
+FETCH_OUTPUT="$(git fetch -q --prune)"
+if [ $? != 0 ]; then
+	echo "ERROR:"
+	echo "$FETCH_OUTPUT"
+	exit 2
+fi
+
+CHECKOUT_OUTPUT="$(git checkout -q --detach origin/$DESTINATION_BRANCH)"
+if [ $? != 0 ]; then
+	echo "ERROR:"
+	echo "$CHECKOUT_OUTPUT"
+	exit 3
+fi
+
+MERGE_MESSAGE="Merge remote-tracking branch 'origin/$BRANCH_TO_MERGE' into $DESTINATION_BRANCH"
+MERGE_OUTPUT=$(git merge -S --no-ff -m "$MERGE_MESSAGE" origin/$BRANCH_TO_MERGE)
+if [ $? != 0 ]; then
+	echo "ERROR:"
+	echo "$MERGE_OUTPUT"
+	exit 4
+fi
+
+PUSH_OUTPUT="$(git push -q origin HEAD:$DESTINATION_BRANCH)"
+if [ $? != 0 ]; then
+	echo "ERROR:"
+	echo "$PUSH_OUTPUT"
+	exit 5
+fi
+
+if [ "$PRUNE_FLAG" = off ]; then
+	PUSH_EMPTY_BRANCH="$(git push -q origin :$BRANCH_TO_MERGE)"
+	if [ $? != 0 ]; then
+		echo "ERROR:"
+		echo "$PUSH_EMPTY_BRANCH"
+		exit 6
 	fi
-}
-
-current_branch="$(git symbolic-ref --short HEAD)"
-stash_output="$(git stash save)"
-
-git fetch -q --prune || exit_with_err
-git checkout -q --detach origin/$dest_branch || exit_with_err 3
-
-merge_message="Merge remote-tracking branch 'origin/$src_branch' into $dest_branch"
-
-git merge -S --no-ff -m "$merge_message" origin/$src_branch || exit_with_err 4
-git push -q origin HEAD:$dest_branch
-
-if [ "$prune_flag" = off ]; then
-	git push -q origin :$src_branch || exit_with_err
-	git branch -d $src_branch || exit_with_err
+	DELETE_LOCAL_BRANCH="$(git branch -d $BRANCH_TO_MERGE)"
+	if [ $? != 0 ]; then
+		echo "ERROR:"
+		echo "$DELETE_LOCAL_BRANCH"
+		exit 7
+	fi
 fi
 
-git checkout -q $current_branch || exit_with_err 8
+CHECKOUT_ORIGINAL_OUTPUT="$(git checkout -q $CURRENT_BRANCH)"
+if [ $? != 0 ]; then
+	echo "ERROR:"
+	echo "$CHECKOUT_ORIGINAL_OUTPUT"
+	exit 8
+fi
 
-if [ "$stash_output" != "No local changes to save" ]; then
-	git stash pop || exit_with_err
+if [ "$STASH_OUTPUT" != "No local changes to save" ]; then
+	POP_STASH="$(git stash pop)"
+	if [ $? != 0 ]; then
+		echo "ERROR:"
+		echo "$POP_STASH"
+		exit 9
+	fi
 fi
 
 exit 0

--- a/git-promote
+++ b/git-promote
@@ -1,37 +1,81 @@
 #!/bin/bash
 
-prerelease_tag=$1
-target_branch=$2
+PRERELEASE_TAG=$1
+TARGET_BRANCH=$2
 
-index=`expr index "$prerelease_tag" -`
-release_tag=${prerelease_tag:0:index-1}
+INDEX=`expr index "$PRERELEASE_TAG" -`
+RELEASE_TAG=${PRERELEASE_TAG:0:INDEX-1}
+
+CURRENT_BRANCH="$(git symbolic-ref --short HEAD)"
+
+STASH_OUTPUT=''
 
 function unstash_changes()
 {
-	if [ "$stash_output" != "No local changes to save" ]; then
-		git stash pop || exit_with_err
+	if [ "$STASH_OUTPUT" != "No local changes to save" ]; then
+		POP_STASH="$(git stash pop)"
+		if [ $? != 0 ]; then
+			echo "ERROR:"
+			echo "$POP_STASH"
+			exit 8
+		fi
 	fi
 }
 
-function exit_with_err() {
-	echo "Error performing operation. Exiting."
+STASH_OUTPUT="$(git stash save)"
+if [ $? != 0 ]; then
+	echo "ERROR:"
+	echo "$STASH_OUTPUT"
+	exit 1
+fi
+
+FETCH_OUTPUT="$(git fetch -q --tags)"
+if [ $? != 0 ]; then
+	echo "ERROR:"
+	echo "$FETCH_OUTPUT"
 	unstash_changes
-	if [ $1 ]; then
-		exit $1
-	else
-		exit 1
-	fi
-}
+	exit 2
+fi
 
-current_branch="$(git symbolic-ref --short HEAD)"
-stash_output="$(git stash save)"
+CHECKOUT_OUTPUT="$(git checkout -q $TARGET_BRANCH)"
+if [ $? != 0 ]; then
+	echo "ERROR:"
+	echo "Your target branch does not appear to exist"
+	unstash_changes
+	exit 3
+fi
 
-git fetch -q --tags || exit_with_err
-git checkout -q $target_branch || exit_with_err 3
-git merge -q --ff-only origin/$target_branch || exit_with_err 4
-git merge -q -S --no-ff $prerelease_tag || exit_with_err 5
-git tag -s $release_tag -m $release_tag || exit_with_err 6
-git push -q origin $target_branch --tags || exit_with_err
+FF_MASTER_OUTPUT="$(git merge -q --ff-only origin/$TARGET_BRANCH)"
+if [ $? != 0 ]; then
+	echo "ERROR:"
+	echo "$FF_MASTER_OUTPUT"
+	unstash_changes
+	exit 4
+fi
+
+MERGE_OUTPUT="$(git merge -q -S --no-ff $PRERELEASE_TAG)"
+if [ $? != 0 ]; then
+	echo "ERROR:"
+	echo "$MERGE_OUTPUT"
+	unstash_changes
+	exit 5
+fi
+
+TAG_OUTPUT="$(git tag -s $RELEASE_TAG -m $RELEASE_TAG)"
+if [ $? != 0 ]; then
+	echo "ERROR:"
+	echo "$TAG_OUTPUT"
+	unstash_changes
+	exit 6
+fi
+
+PUSH_OUTPUT="$(git push -q origin $TARGET_BRANCH --tags)"
+if [ $? != 0 ]; then
+	echo "ERROR:"
+	echo "TAG_OUTPUT"
+	unstash_changes
+	exit 7
+fi
 
 unstash_changes
 


### PR DESCRIPTION
This reverts commit a49b3ed2b392c7008ca5e0a0a86a9f50a44b5a3f, reversing
changes made to 8bef3c82b914da456c8dce3418cda38b60842672.

The code cleanup contained some tweaks to the script logic, removing error handling in the case of some failures, making it difficult to merge extant PRs. This refactor can be conducted on the updated scripts once other changes are merged.