### PR TITLE
Only prune feature branch if it exists locally

### DIFF
--- a/git-mergepr
+++ b/git-mergepr
@@ -106,7 +106,10 @@ echo "Push Successful!"
 
 if [ "$PRUNE_FLAG" = off ]; then
 	run_command "git push origin :$BRANCH_TO_MERGE" || { restore_original_state && exit 6; }
-	run_command "git branch -d $BRANCH_TO_MERGE" || { restore_original_state && exit 7; }
+	BRANCH_EXISTS="$(git show-ref refs/heads/$BRANCH_TO_MERGE)"
+	if [ -n "$BRANCH_EXISTS" ]; then
+		run_command "git branch -d $BRANCH_TO_MERGE" || { restore_original_state && exit 7; }
+	fi
 fi
 
 restore_original_state


### PR DESCRIPTION
Prior to this commit, if there was no local copy of the feature branch,
the git-mergepr command would fail on the auto-prune step, as it would
attempt to delete a branch that does not exist, causing the command to
complain and exit with an error, even though the merge+push step succeeded.
This commit alters the script to only attempt to delete the branch if it does
exist. However, if the local branch contains commits that have not been
fully merged, mergepr will still attempt to delete it and fail.

In the future, we may want to explicitly NOT try to delete the branch if it contains
unmerged commits, with something like:
```
BRANCH_EXISTS="$(git show-ref refs/heads/$BRANCH_TO_MERGE)"
FF_READY="$(git merge-base --is-ancestor $BRANCH_TO_MERGE origin/$BRANCH_TO_MERGE)"
if [ -n BRANCH_EXISTS && FF_READY]; then
    echo 'Fast-forward is possible. Deleting local branch...'
    git branch -d ...
else
```
This PR closes #12 