### PR TITLE
Copy commands by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,21 @@ Running the tests will also require python, pip, and `behave`.
 
 ## Installation
 
+There are two different methods for suggested installation, depending on whether
+you plan to alter this tool or just use the secure commands out of the box.
+
+### Installation for development
+
 Clone the `kevlar-laces` repository to wherever you normally keep your
-repositories. The install script will create symlinks to that location.
-For example purposes, the `~/repos` directory is used, but any persistent
-location will work.
+repositories. Run the script with the `--dev` flag. The install script will
+create symlinks to that location. For example purposes, the `~/repos` directory
+ is used, but any persistent location will work.
 
 ```
 $ cd ~/repos
 $ git clone git@github.com:PolySync/kevlar-laces
 $ cd kevlar-laces
-$ . ./install.sh
+$ . ./install.sh --dev
 ```
 
 The above example explicitly runs the install script with a preceding `.`. This
@@ -41,6 +46,33 @@ already have `$HOME/.local/bin` in `$PATH` or you do not need to run the various
 kevlar-laces git subcommands in the _current_ terminal session, then
 `./install.sh` will suffice.
 
+### Installation for development
+
+Clone the `kevlar-laces` repository to wherever you normally keep your
+repositories. By default, the install script will copy the secure commands into
+`~/.local/bin` (creating the directory if it needs to). After that, you will be
+able to delete `kevlar-laces` and still use the secure git commands. For
+example purposes, the `~/repos` directory is used, but any persistent location
+will work.
+
+```
+$ cd ~/repos
+$ git clone git@github.com:PolySync/kevlar-laces
+$ cd kevlar-laces
+$ . ./install.sh
+$ cd ..
+$ rm -rf kevlar-laces
+```
+
+The above example explicitly runs the install script with a preceding `.`. This
+is solely for convenience in the _current_ terminal session, because
+`install.sh` may need to modify `$PATH` to include `$HOME/.local/bin`. If you
+already have `$HOME/.local/bin` in `$PATH` or you do not need to run the various
+kevlar-laces git subcommands in the _current_ terminal session, then
+`./install.sh` will suffice. It also demonstrates deletion of the repository
+after installation of the scripts, which is completely optional. If you do
+delete the repo, you will have to re-clone and re-install in order to get
+updates.
 
 ## Usage
 

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,52 @@
 #!/bin/bash
 
+print_usage(){
+  echo "install kevlar-laces"
+  echo ""
+  echo "USAGE: ./install.sh [--dev]"
+  echo ""
+  echo "Pass the '--dev' flag in order to keep the secure-git scripts"
+  echo "in this directory and create symlinks to them in '~/.local/bin/'."
+  echo "By default this script will copy the scripts to this destination."
+  echo "Use this option if you plan to customize or alter these commands."
+}
+
+DEV_FLAG=off
+while [ $# -ne 0 ]
+do
+  case "$1" in
+    -h | -help )
+      print_usage
+      exit 0
+      ;;
+    --dev )
+      DEV_FLAG=on
+      shift
+      ;;
+    * )
+      echo "ERROR: unable to parse options."
+      print_usage
+      exit -1
+      ;;
+  esac
+done
+
 DEST_DIR=$HOME/.local/bin
 echo "Ensuring $DEST_DIR exists"
 mkdir -p $DEST_DIR
 
+if [ $DEV_FLAG = on ]; then
+  CMD='ln -sf'
+  MESSAGE="Creating symlink for"
+else
+  CMD='cp'
+  MESSAGE="Copying subcommand"
+fi
+
 for subcommand in `ls git-*`
 do
-  echo "Creating symlink for $subcommand"
-  ln -sf `pwd`/$subcommand $DEST_DIR
+  echo "$MESSAGE $subcommand"
+  eval "$CMD `pwd`/$subcommand $DEST_DIR"
 done
 
 output=$(echo $PATH | grep -F $DEST_DIR)


### PR DESCRIPTION
Prior to this commit, the install script created symlinks to a directory in the
user's path. This commit changes the default behavior to copy the commands to
the target directory. In order to create symlinks instead, the user can pass the
`--dev` option to `install.sh`. This option facilitates installation for those
who desire to use, but not edit the secure git commands. After installation, as
long as the files are copied, the user can safely delete the repo. To update,
the user can re-clone and re-install.