### PR TITLE
Add git overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ sudo apt install git gnupg2
 ### Installation
 
 Clone the `kevlar-laces` repository to wherever you normally keep your
-repositories. The install script will create symlinks to that location.
+repositories. 
+The install script will create symlinks to that location.
+It will also create an alias for git commands to ensure that the secure versions of `push`, `pull`, and `fetch` are always used. To disable this, run the install script with the `--no-override` option.
 For example purposes, the `~/Repositories` directory is used, but any persistent
 location will work.
 
@@ -33,15 +35,8 @@ location will work.
 cd ~/Repositories
 git clone git@github.com:PolySync/kevlar-laces
 cd kevlar-laces
-. ./install.sh
+./install.sh
 ```
-
-The above example explicitly runs the install script with a preceding `.`. This
-is solely for convenience in the _current_ terminal session, because
-`install.sh` may need to modify `$PATH` to include `$HOME/.local/bin`. If you
-already have `$HOME/.local/bin` in `$PATH` or you do not need to run the various
-kevlar-laces git subcommands in the _current_ terminal session, then
-`./install.sh` will suffice.
 
 ## Usage
 

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,31 @@ then
   eval "export PATH=$PATH:$DEST_DIR"
 fi
 
+if [ "$1" != --no-override ]
+then
+echo "Overriding existing git push, pull, and fetch commands to use secure versions"
+echo "
+# override existing git push, pull, fetch to use secure versions
+kevlar_git () {
+  prefix=\"\"
+  cmd=\$1
+  shift
+  if [ \"\$cmd\" == \"push\" ] || [ \"\$cmd\" == \"pull\" ] || [ \"\$cmd\" == \"fetch\" ]; then
+    prefix=\"secure-\"
+  fi
+  \"\`which git\`\" \"\$prefix\$cmd\" \"\$@\"
+}
+alias git='kevlar_git'" >> $HOME/.bashrc
+
+  if [ $? != 0 ]
+  then
+    echo "Could not write git command overrides to ~/.bashrc"
+    echo "git fetch, pull, and push will not automatically use secure versions"
+  fi
+fi
+
+source $HOME/.bashrc
+
 echo "Installation successful. To learn about usage of this tool, run any of
 the subcommands with the '-h' flag, e.g. 'git merge-pr -h'.
 


### PR DESCRIPTION
Prior to this pull request, users had to remember to use the secure-push, secure-fetch, and secure-pull commands when using git. This pull request adds a section to the install script which sets an alias in ~/.bashrc, enabling kevlar-laces to intercept git commands and prepend them with `secure-` if they are push, pull, or fetch, preventing accidental unsecured actions. This updates the README to reflect those changes. 
This functionality is optional, and can be disabled by passing the `--no-override` flag to the install script.