### PR TITLE
Maint/be loud about key usage

### DIFF
--- a/git-merge-pr
+++ b/git-merge-pr
@@ -100,8 +100,7 @@ if [ $CURRENT_BRANCH = $BRANCH_TO_MERGE ] &&  [ $PRUNE_FLAG = off ]; then
 fi
 
 echo "Stashing any local changes and checking out remote branch 'origin/$DESTINATION_BRANCH'"
-echo "3 GPG signatures may be required to sign stash commit"
-STASH_OUTPUT="$(git stash save -a)" || exit 1;
+STASH_OUTPUT="$(git -c commit.gpgSign=false stash save -a)" || exit 1;
 
 echo "Securely fetching remote branches and revisions"
 echo "GPG signatures required to sign and push to RSL"

--- a/git-merge-pr
+++ b/git-merge-pr
@@ -102,24 +102,29 @@ fi
 echo "Stashing any local changes and checking out remote branch 'origin/$DESTINATION_BRANCH'"
 STASH_OUTPUT="$(git -c commit.gpgSign=false stash save -a)" || exit 1;
 
-echo "Securely fetching remote branches and revisions"
-echo "<---- GPG signature required to commit RSL fetch entry for $DESTINATION_BRANCH"
+echo "Securely fetching remote branches and revisions:"
+echo "    Fetching $DESTINATION_BRANCH..."
+echo "    <---- GPG signature required to commit RSL fetch entry"
 run_command "git secure-fetch origin $DESTINATION_BRANCH" || { restore_original_state && exit 2; }
-echo "<---- GPG signature required to commit RSL fetch entry for $BRANCH_TO_BE_MERGED"
-run_command "git secure-fetch origin $BRANCH_TO_BE_MERGED" || { restore_original_state && exit 2; }
+echo "    Fetching $BRANCH_TO_MERGE..."
+echo "    <---- GPG signature required to commit RSL fetch entry"
+run_command "git secure-fetch origin $BRANCH_TO_MERGE" || { restore_original_state && exit 2; }
 
-run_command "git checkout --detach origin/$DESTINATION_BRANCH" || { unstash_changes && exit 3; }
 
 echo "Cleaning up local repository"
 run_command "git gc"
 
-echo "Attempting to merge"
+echo "Checking out $DESTINATION_BRANCH"
+run_command "git checkout --detach origin/$DESTINATION_BRANCH" || { unstash_changes && exit 3; }
+
+echo "Merging $BRANCH_TO_MERGE into $DESTINATION_BRANCH"
 MERGE_MESSAGE="\"Merge 'origin/$BRANCH_TO_MERGE' into $DESTINATION_BRANCH\""
 run_command "git merge -S --no-ff -m $MERGE_MESSAGE origin/$BRANCH_TO_MERGE" || { restore_original_state && exit 4; }
 echo "Merge Successful!"
 
-echo "Attempting to push to remote repository 'origin'"
-echo "<---- 2 GPG signatures required to clearsign RSL push entry and sign RSL commit"
+echo "Pushing to remote repository 'origin'"
+echo "    clearsigning RSL push entry and signing RSL push commit"
+echo "    <---- 2 GPG signatures required" 
 run_command "git secure-push origin HEAD:$DESTINATION_BRANCH" || { restore_original_state && exit 5; }
 echo "Push Successful!"
 

--- a/git-merge-pr
+++ b/git-merge-pr
@@ -103,7 +103,7 @@ echo "Stashing any local changes and checking out remote branch 'origin/$DESTINA
 STASH_OUTPUT="$(git -c commit.gpgSign=false stash save -a)" || exit 1;
 
 echo "Securely fetching remote branches and revisions"
-echo "GPG signatures required to sign and push to RSL"
+echo "GPG signature required to commit RSL fetch entry"
 run_command "git secure-fetch" || { restore_original_state && exit 2; }
 run_command "git checkout --detach origin/$DESTINATION_BRANCH" || { unstash_changes && exit 3; }
 
@@ -116,7 +116,7 @@ run_command "git merge -S --no-ff -m $MERGE_MESSAGE origin/$BRANCH_TO_MERGE" || 
 echo "Merge Successful!"
 
 echo "Attempting to push to remote repository 'origin'"
-echo "GPG signatures required to sign RSL entry and commit"
+echo "2 GPG signatures required to clearsign RSL push entry and sign RSL commit"
 run_command "git secure-push origin HEAD:$DESTINATION_BRANCH" || { restore_original_state && exit 5; }
 echo "Push Successful!"
 

--- a/git-merge-pr
+++ b/git-merge-pr
@@ -103,9 +103,9 @@ echo "Stashing any local changes and checking out remote branch 'origin/$DESTINA
 STASH_OUTPUT="$(git -c commit.gpgSign=false stash save -a)" || exit 1;
 
 echo "Securely fetching remote branches and revisions"
-echo "GPG signature required to commit RSL fetch entry for $DESTINATION_BRANCH"
+echo "<---- GPG signature required to commit RSL fetch entry for $DESTINATION_BRANCH"
 run_command "git secure-fetch origin $DESTINATION_BRANCH" || { restore_original_state && exit 2; }
-echo "GPG signature required to commit RSL fetch entry for $BRANCH_TO_BE_MERGED"
+echo "<---- GPG signature required to commit RSL fetch entry for $BRANCH_TO_BE_MERGED"
 run_command "git secure-fetch origin $BRANCH_TO_BE_MERGED" || { restore_original_state && exit 2; }
 
 run_command "git checkout --detach origin/$DESTINATION_BRANCH" || { unstash_changes && exit 3; }
@@ -119,7 +119,7 @@ run_command "git merge -S --no-ff -m $MERGE_MESSAGE origin/$BRANCH_TO_MERGE" || 
 echo "Merge Successful!"
 
 echo "Attempting to push to remote repository 'origin'"
-echo "2 GPG signatures required to clearsign RSL push entry and sign RSL commit"
+echo "<---- 2 GPG signatures required to clearsign RSL push entry and sign RSL commit"
 run_command "git secure-push origin HEAD:$DESTINATION_BRANCH" || { restore_original_state && exit 5; }
 echo "Push Successful!"
 

--- a/git-merge-pr
+++ b/git-merge-pr
@@ -100,9 +100,11 @@ if [ $CURRENT_BRANCH = $BRANCH_TO_MERGE ] &&  [ $PRUNE_FLAG = off ]; then
 fi
 
 echo "Stashing any local changes and checking out remote branch 'origin/$DESTINATION_BRANCH'"
+echo "3 GPG signatures may be required to sign stash commit"
 STASH_OUTPUT="$(git stash save -a)" || exit 1;
 
 echo "Securely fetching remote branches and revisions"
+echo "GPG signatures required to sign and push to RSL"
 run_command "git secure-fetch" || { restore_original_state && exit 2; }
 run_command "git checkout --detach origin/$DESTINATION_BRANCH" || { unstash_changes && exit 3; }
 
@@ -115,6 +117,7 @@ run_command "git merge -S --no-ff -m $MERGE_MESSAGE origin/$BRANCH_TO_MERGE" || 
 echo "Merge Successful!"
 
 echo "Attempting to push to remote repository 'origin'"
+echo "GPG signatures required to sign RSL entry and commit"
 run_command "git secure-push origin HEAD:$DESTINATION_BRANCH" || { restore_original_state && exit 5; }
 echo "Push Successful!"
 

--- a/git-promote
+++ b/git-promote
@@ -58,8 +58,13 @@ run_command()
 echo "Attempting to securely promote prerelease $PRERELEASE_TAG into 'origin/$TARGET_BRANCH' with tag $RELEASE_TAG"
 
 echo "Stashing any local changes and checking out remote branch 'origin/$TARGET_BRANCH'"
+echo "3 GPG signatures may be required to create stash commit."
 STASH_OUTPUT="$(git stash save -a)" || exit 1;
+
+echo "Running secure-fetch on tag $PRERELEASE_TAG."
+echo "GPG authentication required to sign RSL"
 run_command "git secure-fetch $PRERELEASE_TAG" || { unstash_changes && exit 2; }
+
 run_command "git checkout $TARGET_BRANCH" || { unstash_changes && exit 3; }
 
 echo "Attempting to fast-forward latest changes"
@@ -67,10 +72,12 @@ run_command "git merge --ff-only origin/$TARGET_BRANCH" || { restore_original_st
 echo "Fast forward successful!"
 
 echo "Attempting to merge tagged version $PRERELEASE_TAG into $TARGET_BRANCH"
+echo "Signing merge commit. GPG authentication required."
 run_command "git merge -S --no-ff $PRERELEASE_TAG" || { restore_original_state && exit 5; }
 echo "Merge successful!"
 
 echo "Tagging HEAD with $RELEASE_TAG"
+echo "Signing tag object. GPG authentication required."
 run_command "git tag -s $RELEASE_TAG -m $RELEASE_TAG" || { restore_original_state && exit 6; }
 
 echo "Attempting to push to remote repository 'origin'"

--- a/git-promote
+++ b/git-promote
@@ -61,7 +61,7 @@ echo "Stashing any local changes and checking out remote branch 'origin/$TARGET_
 STASH_OUTPUT="$(git -c commit.gpgSign=false stash save -a)" || exit 1;
 
 echo "Running secure-fetch on tag $PRERELEASE_TAG."
-echo "GPG authentication required to sign RSL"
+echo "GPG signature required to sign RSL fetch entry for $PRERELEASE_TAG"
 run_command "git secure-fetch $PRERELEASE_TAG" || { unstash_changes && exit 2; }
 
 run_command "git checkout $TARGET_BRANCH" || { unstash_changes && exit 3; }
@@ -80,7 +80,9 @@ echo "Signing tag object. GPG authentication required."
 run_command "git tag -s $RELEASE_TAG -m $RELEASE_TAG" || { restore_original_state && exit 6; }
 
 echo "Attempting to push to remote repository 'origin'"
+echo "2 GPG signatures required to clearsign RSL entry and sign RSL commit for branch $TARGET_BRANCH"
 run_command "git secure-push origin $TARGET_BRANCH" || { restore_original_state && exit 7; }
+echo "2 GPG signatures required to clearsign RSL entry and sign RSL commit for tag $RELEASE_TAG"
 run_command "git secure-push origin $RELEASE_TAG" || { restore_original_state && exit 7; }
 echo "Push Successful!"
 

--- a/git-promote
+++ b/git-promote
@@ -61,7 +61,7 @@ echo "Stashing any local changes and checking out remote branch 'origin/$TARGET_
 STASH_OUTPUT="$(git -c commit.gpgSign=false stash save -a)" || exit 1;
 
 echo "Running secure-fetch on tag $PRERELEASE_TAG."
-echo "GPG signature required to sign RSL fetch entry for $PRERELEASE_TAG"
+echo "<---- GPG signature required to sign RSL fetch entry for $PRERELEASE_TAG"
 run_command "git secure-fetch $PRERELEASE_TAG" || { unstash_changes && exit 2; }
 
 run_command "git checkout $TARGET_BRANCH" || { unstash_changes && exit 3; }
@@ -80,9 +80,9 @@ echo "Signing tag object. GPG authentication required."
 run_command "git tag -s $RELEASE_TAG -m $RELEASE_TAG" || { restore_original_state && exit 6; }
 
 echo "Attempting to push to remote repository 'origin'"
-echo "2 GPG signatures required to clearsign RSL entry and sign RSL commit for branch $TARGET_BRANCH"
+echo "<---- 2 GPG signatures required to clearsign RSL entry and sign RSL commit for branch $TARGET_BRANCH"
 run_command "git secure-push origin $TARGET_BRANCH" || { restore_original_state && exit 7; }
-echo "2 GPG signatures required to clearsign RSL entry and sign RSL commit for tag $RELEASE_TAG"
+echo "<---- 2 GPG signatures required to clearsign RSL entry and sign RSL commit for tag $RELEASE_TAG"
 run_command "git secure-push origin $RELEASE_TAG" || { restore_original_state && exit 7; }
 echo "Push Successful!"
 

--- a/git-promote
+++ b/git-promote
@@ -60,29 +60,40 @@ echo "Attempting to securely promote prerelease $PRERELEASE_TAG into 'origin/$TA
 echo "Stashing any local changes and checking out remote branch 'origin/$TARGET_BRANCH'"
 STASH_OUTPUT="$(git -c commit.gpgSign=false stash save -a)" || exit 1;
 
-echo "Running secure-fetch on tag $PRERELEASE_TAG."
-echo "<---- GPG signature required to sign RSL fetch entry for $PRERELEASE_TAG"
+echo "Securely fetching remote branches and tags."
+echo "    Fetching $PRERELEASE_TAG..."
+echo "    Signing RSL fetch entry for $PRERELEASE_TAG..."
+echo "    <---- GPG signature required"
 run_command "git secure-fetch $PRERELEASE_TAG" || { unstash_changes && exit 2; }
+echo "    Fetching $TARGET_BRANCH..."
+echo "    Signing RSL fetch entry for $TARGET_BRANCH..."
+echo "    <---- GPG signature required"
+run_command "git secure-fetch $TARGET_BRANCH" || { unstash_changes && exit 2; }
 
+echo "Checking out $TARGET_BRANCH"
 run_command "git checkout $TARGET_BRANCH" || { unstash_changes && exit 3; }
 
-echo "Attempting to fast-forward latest changes"
+echo "Fast-forward latest changes"
 run_command "git merge --ff-only origin/$TARGET_BRANCH" || { restore_original_state && exit 4; }
 echo "Fast forward successful!"
 
-echo "Attempting to merge tagged version $PRERELEASE_TAG into $TARGET_BRANCH"
-echo "Signing merge commit. GPG authentication required."
+echo "Merging tagged version $PRERELEASE_TAG into $TARGET_BRANCH"
+echo "    Signing merge commit."
+echo "    <---- GPG authentication required."
 run_command "git merge -S --no-ff $PRERELEASE_TAG" || { restore_original_state && exit 5; }
 echo "Merge successful!"
 
 echo "Tagging HEAD with $RELEASE_TAG"
-echo "Signing tag object. GPG authentication required."
+echo "    Signing tag object."
+echo "    <---- GPG authentication required."
 run_command "git tag -s $RELEASE_TAG -m $RELEASE_TAG" || { restore_original_state && exit 6; }
 
 echo "Attempting to push to remote repository 'origin'"
-echo "<---- 2 GPG signatures required to clearsign RSL entry and sign RSL commit for branch $TARGET_BRANCH"
+echo "    Clearsigning RSL push entry and signing RSL commit for branch $TARGET_BRANCH"
+echo "    <---- 2 GPG signatures required"
 run_command "git secure-push origin $TARGET_BRANCH" || { restore_original_state && exit 7; }
-echo "<---- 2 GPG signatures required to clearsign RSL entry and sign RSL commit for tag $RELEASE_TAG"
+echo "    Clearsigning RSL push entry and signing RSL commit for tag $RELEASE_TAG"
+echo "    <---- 2 GPG signatures required"
 run_command "git secure-push origin $RELEASE_TAG" || { restore_original_state && exit 7; }
 echo "Push Successful!"
 

--- a/git-promote
+++ b/git-promote
@@ -58,8 +58,7 @@ run_command()
 echo "Attempting to securely promote prerelease $PRERELEASE_TAG into 'origin/$TARGET_BRANCH' with tag $RELEASE_TAG"
 
 echo "Stashing any local changes and checking out remote branch 'origin/$TARGET_BRANCH'"
-echo "3 GPG signatures may be required to create stash commit."
-STASH_OUTPUT="$(git stash save -a)" || exit 1;
+STASH_OUTPUT="$(git -c commit.gpgSign=false stash save -a)" || exit 1;
 
 echo "Running secure-fetch on tag $PRERELEASE_TAG."
 echo "GPG authentication required to sign RSL"

--- a/git-secure-fetch
+++ b/git-secure-fetch
@@ -313,8 +313,7 @@ then
 fi
 
 echo "Stashing any local changes."
-echo "3 GPG signatures may be required."
-STASH_OUTPUT="$(git stash save -a)"
+STASH_OUTPUT="$(git -c commit.gpgSign=false stash save -a)"
 if [ $? != 0 ]; then
   echo "ERROR:"
   echo "$STASH_OUTPUT"

--- a/git-secure-fetch
+++ b/git-secure-fetch
@@ -33,7 +33,7 @@ function update_rsl_fetch {
   # Commit the new RSL
   git add $RSL
   echo "Committing the fetch entry to the RSL branch."
-  echo "GPG signature required."
+  echo "<---- GPG signature required."
 
   git commit -S -m "Adding the fetch entry at RSL"
 }
@@ -57,8 +57,8 @@ function rsl_init {
 
   # Commit the new RSL
   git add 1
-  echo "Commiting inital entries to RSL branch."
-  echo "GPG signature required."
+  echo "Committing inital entries to RSL branch."
+  echo "<---- GPG signature required."
   git commit -S -qm "Commiting the changes at RSL"
 
 }

--- a/git-secure-fetch
+++ b/git-secure-fetch
@@ -32,6 +32,9 @@ function update_rsl_fetch {
 
   # Commit the new RSL
   git add $RSL
+  echo "Committing the fetch entry to the RSL branch."
+  echo "GPG signature required."
+
   git commit -S -m "Adding the fetch entry at RSL"
 }
 
@@ -54,6 +57,8 @@ function rsl_init {
 
   # Commit the new RSL
   git add 1
+  echo "Commiting inital entries to RSL branch."
+  echo "GPG signature required."
   git commit -S -qm "Commiting the changes at RSL"
 
 }
@@ -307,6 +312,8 @@ then
     exit 0
 fi
 
+echo "Stashing any local changes."
+echo "3 GPG signatures may be required."
 STASH_OUTPUT="$(git stash save -a)"
 if [ $? != 0 ]; then
   echo "ERROR:"

--- a/git-secure-pull
+++ b/git-secure-pull
@@ -31,6 +31,8 @@ function update_rsl_fetch {
   dd if=/dev/urandom bs=16 count=1 of=$RSL
 
   # Commit the new RSL
+  echo "Committing fetch entry to RSL branch."
+  echo "GPG signature required."
   git add $RSL
   git commit -S -m "Adding the fetch entry at RSL"
 }
@@ -53,6 +55,8 @@ function rsl_init {
   dd if=/dev/urandom bs=16 count=1 of=1
 
   # Commit the new RSL
+  echo "Committing inital entries to the RSL branch."
+  echo "GPG signature required."
   git add 1
   git commit -S -qm "Commiting the changes at RSL"
 
@@ -276,7 +280,7 @@ function restore_original_state() {
 }
 
 
-#Get Current Brach
+#Get Current Branch
 PRIOR_BRANCH=$(git symbolic-ref --short HEAD)
 
 while [ $# -ne 0 ]
@@ -307,6 +311,8 @@ then
     exit 0
 fi
 
+echo "Stashing any local changes."
+echo "3 GPG signatures may be required."
 STASH_OUTPUT="$(git stash save -a)"
 if [ $? != 0 ]; then
   echo "ERROR:"

--- a/git-secure-pull
+++ b/git-secure-pull
@@ -32,7 +32,7 @@ function update_rsl_fetch {
 
   # Commit the new RSL
   echo "Committing fetch entry to RSL branch."
-  echo "GPG signature required."
+  echo "<---- GPG signature required."
   git add $RSL
   git commit -S -m "Adding the fetch entry at RSL"
 }
@@ -56,7 +56,7 @@ function rsl_init {
 
   # Commit the new RSL
   echo "Committing inital entries to the RSL branch."
-  echo "GPG signature required."
+  echo "<---- GPG signature required."
   git add 1
   git commit -S -qm "Commiting the changes at RSL"
 

--- a/git-secure-pull
+++ b/git-secure-pull
@@ -312,8 +312,7 @@ then
 fi
 
 echo "Stashing any local changes."
-echo "3 GPG signatures may be required."
-STASH_OUTPUT="$(git stash save -a)"
+STASH_OUTPUT="$(git -c commit.gpgSign=false stash save -a)"
 if [ $? != 0 ]; then
   echo "ERROR:"
   echo "$STASH_OUTPUT"

--- a/git-secure-push
+++ b/git-secure-push
@@ -85,7 +85,7 @@ function update_rsl_fetch {
 
     git add $RSL
     echo "Commiting fetch entry to RSL branch."
-    echo "GPG signature required."
+    echo "<---- GPG signature required."
     git commit -S -qm "Adding the fetch entry at RSL"
 }
 
@@ -137,7 +137,7 @@ function sign_rsl {
   RSL=$(($LAST_ENTRY+1))
   #Sign the rsl
   echo "Clearsigning RSL entry"
-  echo "GPG signature required"
+  echo "<---- GPG signature required"
   cat rsl.tmp |gpg2 --default-key $GPG_KEY --clearsign >$RSL
 
   #Remove temp file
@@ -146,7 +146,7 @@ function sign_rsl {
   # Commit the new RSL
   git add $RSL
   echo "Commiting push entry to RSL branch"
-  echo "GPG signature required"
+  echo "<---- GPG signature required"
   git commit -S -qm "Adding the push entry at RSL"
 }
 

--- a/git-secure-push
+++ b/git-secure-push
@@ -370,8 +370,7 @@ then
 fi
 
 echo "Stashing any local changes"
-echo "Three GPG signatures may be required."
-STASH_OUTPUT="$(git stash save -a)"
+STASH_OUTPUT="$(git -c commit.gpgSign=false stash save -a)"
 if [ $? != 0 ]; then
   echo "ERROR:"
   echo "$STASH_OUTPUT"

--- a/git-secure-push
+++ b/git-secure-push
@@ -84,6 +84,8 @@ function update_rsl_fetch {
     echo `od -A n -t d -N 4 /dev/urandom` >$RSL
 
     git add $RSL
+    echo "Commiting fetch entry to RSL branch."
+    echo "GPG signature required."
     git commit -S -qm "Adding the fetch entry at RSL"
 }
 
@@ -133,7 +135,9 @@ function sign_rsl {
 
   LAST_ENTRY=$(find_last_entry_number)
   RSL=$(($LAST_ENTRY+1))
-  #Signthe rsl
+  #Sign the rsl
+  echo "Clearsigning RSL entry"
+  echo "GPG signature required"
   cat rsl.tmp |gpg2 --default-key $GPG_KEY --clearsign >$RSL
 
   #Remove temp file
@@ -141,6 +145,8 @@ function sign_rsl {
 
   # Commit the new RSL
   git add $RSL
+  echo "Commiting push entry to RSL branch"
+  echo "GPG signature required"
   git commit -S -qm "Adding the push entry at RSL"
 }
 
@@ -363,6 +369,8 @@ then
   exit 0
 fi
 
+echo "Stashing any local changes"
+echo "Three GPG signatures may be required."
 STASH_OUTPUT="$(git stash save -a)"
 if [ $? != 0 ]; then
   echo "ERROR:"


### PR DESCRIPTION
Prior to this PR, the secure git commands required use of the user's GPG signing key many times to sign RSL entries, stash work, and sign commits. It gave no visible clue as to why it needed the the signatures. This PR adds explanations to stdout which describe the process of the tools, including statements of impending GPG key requests along with what the key will be used to do. It also decreases the number of signatures necessary by temporarily turning off gpg signing during the 'stash local work phase', as there is no need to sign the short-lived stash that is created only for the duration of command execution.

Closes Issue #36 