### PR TITLE
Fetch upstream revisions

### DIFF
--- a/git-merge-pr
+++ b/git-merge-pr
@@ -103,7 +103,9 @@ echo "Stashing any local changes and checking out remote branch 'origin/$DESTINA
 STASH_OUTPUT="$(git stash save -a)" || exit 1;
 
 echo "Securely fetching remote branches and revisions"
-run_command "git secure-fetch" || { restore_original_state && exit 2; }
+run_command "git secure-fetch origin $DESTINATION_BRANCH" || { restore_original_state && exit 2; }
+echo "GPG signature required to create fetch entry for $BRANCH_TO_BE_MERGED"
+run_command "git secure-fetch origin $BRANCH_TO_BE_MERGED" || { restore_original_state && exit 2; }
 run_command "git checkout --detach origin/$DESTINATION_BRANCH" || { unstash_changes && exit 3; }
 
 echo "Cleaning up local repository"


### PR DESCRIPTION
Prior to this commit, merge-pr fetched the latest revisions for whichever branch
they happened to be on when they ran the command. If the user did not already
have up to date copies of both the target branch and the branch to be merged
into it, they ran the risk of pushing incorrect commit history to the remote git
server. This commit securely fetches revisions of both branches before
attemoting to do any merging.

Closes issue #42 