### PR TITLE
Exit if target release already exists in remote repository

### DIFF
--- a/features/promote.feature
+++ b/features/promote.feature
@@ -12,4 +12,12 @@ Feature: Promote to master
     And the master branch should be tagged with the semver of the promoted branch
     And the merge commit should be signed
 
+  @promote
+  Scenario: Release tag already exists on remote
+    Given a local copy of the repo on the master branch
+    And the repo has prerelease tag 1.0.1-devel.2 to promote to master as 1.0.1
+    And the remote repo has a release tag 1.0.1
+    When I run the git-promote command from the command line
+    Then the tag should not be merged
+    And the script should return 11
 

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -6,7 +6,11 @@ import tempfile
 def shell_command(command):
     args_list = shlex.split(command)
     result = subprocess.Popen(args_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout = result.stdout.read() if result.stdout else None
+    stderr = result.stderr.read() if result.stderr else None
     result.wait()
+    return_code = result.returncode
+    return (stdout, stderr, return_code)
 
 def run_with_project_in_path(command, context):
     env = os.environ

--- a/features/unique_error_codes.feature
+++ b/features/unique_error_codes.feature
@@ -54,7 +54,7 @@ Feature: Unique error codes for problematic situations
     And the repo has prerelease tag 1.0.0-devel.1 to promote to master as 1.0.0
     And the 1.0.0 release tag already exists
     When I run the git-promote command from the command line
-    Then the script should return 6
+    Then the script should return 11
 
   @promote
   Scenario: Fail when target branch does not exist

--- a/git-promote
+++ b/git-promote
@@ -15,6 +15,15 @@ CURRENT_BRANCH="$(git symbolic-ref --short HEAD)"
 
 STASH_OUTPUT=''
 
+check_for_release_tag(){
+    TAG_EXISTS="$(git ls-remote --exit-code --tags origin $RELEASE_TAG)"
+    if [ $? = 0 ]; then
+        echo "ERROR: "
+        echo "Release tag $RELEASE_TAG already exists in remote repository origin"
+        exit 11
+    fi
+}
+
 unstash_changes() {
 	if [ "$STASH_OUTPUT" != "No local changes to save" ]; then
 		echo "Attempting to unstash local changes"
@@ -56,6 +65,7 @@ run_command()
 }
 
 echo "Attempting to securely promote prerelease $PRERELEASE_TAG into 'origin/$TARGET_BRANCH' with tag $RELEASE_TAG"
+check_for_release_tag
 
 echo "Stashing any local changes and checking out remote branch 'origin/$TARGET_BRANCH'"
 STASH_OUTPUT="$(git stash save -a)" || exit 1;


### PR DESCRIPTION
Prior to this commit, git-promote would go ahead regardless of existing tags in
origin. This commit adds a check to see if the target release tag to be created
already exists, exiting with an error if it does.

Closes issue #48 