### PR TITLE
run commands in any directory

### DIFF
--- a/features/runs_anywhere_in_project.feature
+++ b/features/runs_anywhere_in_project.feature
@@ -1,0 +1,40 @@
+Feature: Runs successfully from anywhere in git project tree
+  In order to not lose my place
+  As a developer
+  I want the scripts to save and restore my working directory and return me to where I was
+
+  @merge
+  Scenario: Return repo to original directory after running script
+    Given a local copy of the repo on the master branch
+    And the repo has a feature PR that is ready to merge
+    And the project contains subdirectory dir
+    When I run the git-merge-pr command from the dir directory
+    Then the script exits with status 0
+    And the dir directory should exist when I am done
+    And the repo should be returned to the master branch when I am done
+
+  @promote
+  Scenario: Return repo to original directory after running script
+    Given a local copy of the repo on the master branch
+    And the repo has prerelease tag 1.0.1-devel.2 to promote to master as 1.0.1
+    And the project contains subdirectory dir
+    When I run the git-promote command from the dir directory
+    Then the script exits with status 0
+    And the dir directory should exist when I am done
+    And the repo should be returned to the master branch when I am done
+
+  @securefetch
+  @securepush
+  @securepull
+  Scenario Outline: Return repo to original directory after running script
+    Given a local copy of the repo on the feature branch
+    And the project contains subdirectory dir
+    When I run <command> from the dir directory
+    Then the script exits with status 0
+    And the dir directory should exist when I am done
+    And the repo should be returned to the feature branch when I am done
+  Examples:
+    | command          |
+    | git secure-fetch |
+    | git secure-pull  |
+    | git secure-push  |

--- a/features/steps/mergepr.py
+++ b/features/steps/mergepr.py
@@ -39,6 +39,11 @@ def step_impl(context, target):
     command = 'git -C {0} merge-pr {1} {2}'.format(context.mock_developer_dir, context.branch_name, context.target_branch)
     context.out, context.err, context.rc = utils.run_with_project_in_path(command, context)
 
+@when('I run the git-merge-pr command from the {directory} directory')
+def step_impl(context, directory):
+    command = 'git -C {0} merge-pr feature devel'.format(context.wd)
+    context.out, context.err, context.rc = utils.run_with_project_in_path(command, context)
+
 @when('I run the git-merge-pr --no-prune command targeting {target}')
 def step_impl(context, target):
     context.target_branch = target

--- a/features/steps/promote.py
+++ b/features/steps/promote.py
@@ -21,7 +21,6 @@ def step_impl(context, release):
     utils.shell_command('git -C {0} tag -f {1}'.format(context.mock_github_dir, release))
     out, err, rc = utils.shell_command('git -C {0} ls-remote --exit-code --tags origin {1}'.format(context.mock_developer_dir, release))
     assert_that(rc, equal_to(0))
-    
 
 @when('I run the git-promote command from the command line')
 def step_impl(context):
@@ -31,6 +30,11 @@ def step_impl(context):
 @when('I run the git-promote command targeting {branch}')
 def step_impl(context, branch):
     command = 'git -C {0} promote {1} {2}'.format(context.mock_developer_dir, context.prerelease, branch)
+    context.out, context.err, context.rc = utils.run_with_project_in_path(command, context)
+
+@when('I run the git-promote command from the {directory} directory')
+def step_impl(context, directory):
+    command = 'git -C {0} promote {1} {2}'.format(context.wd, context.prerelease, context.target)
     context.out, context.err, context.rc = utils.run_with_project_in_path(command, context)
 
 @then('the tag should be merged')

--- a/git-merge-pr
+++ b/git-merge-pr
@@ -47,6 +47,7 @@ do
 done
 
 CURRENT_BRANCH="$(git symbolic-ref --short HEAD)"
+WORKING_DIRECTORY=$(pwd)
 
 unstash_changes() {
 	if [ "$STASH_OUTPUT" != "No local changes to save" ]; then
@@ -74,7 +75,8 @@ restore_original_state() {
 		echo "$CHECKOUT_ORIGINAL_OUTPUT"
 		exit 8
 	fi
-	unstash_changes
+    unstash_changes
+    cd $WORKING_DIRECTORY
 }
 
 run_command()
@@ -101,6 +103,7 @@ fi
 
 echo "Stashing any local changes and checking out remote branch 'origin/$DESTINATION_BRANCH'"
 STASH_OUTPUT="$(git -c commit.gpgSign=false stash save -a)" || exit 1;
+cd $(git rev-parse --show-toplevel)
 
 echo "Securely fetching remote branches and revisions:"
 echo "    Fetching $DESTINATION_BRANCH..."

--- a/git-promote
+++ b/git-promote
@@ -12,6 +12,7 @@ INDEX=`expr index "$PRERELEASE_TAG" -`
 RELEASE_TAG=${PRERELEASE_TAG:0:INDEX-1}
 
 CURRENT_BRANCH="$(git symbolic-ref --short HEAD)"
+WORKING_DIRECTORY=$(pwd)
 
 STASH_OUTPUT=''
 
@@ -51,6 +52,7 @@ restore_original_state()
 		exit 8
 	fi
 	unstash_changes
+    cd $WORKING_DIRECTORY
 }
 
 run_command()
@@ -69,6 +71,7 @@ check_for_release_tag
 
 echo "Stashing any local changes and checking out remote branch 'origin/$TARGET_BRANCH'"
 STASH_OUTPUT="$(git -c commit.gpgSign=false stash save -a)" || exit 1;
+cd $(git rev-parse --show-toplevel)
 
 echo "Securely fetching remote branches and tags."
 echo "    Fetching $PRERELEASE_TAG..."

--- a/git-secure-fetch
+++ b/git-secure-fetch
@@ -64,6 +64,7 @@ function rsl_init {
 }
 
 function find_last_entry_number {
+  # the number of files in the RSL branch
   echo $(find . -maxdepth 1 -type f | grep -v 'rsl.tmp' | wc -l)
 }
 
@@ -252,7 +253,6 @@ function rsl_verify {
 
 }
 
-#************************************************************************************
 function unstash_changes() {
   if [ "$STASH_OUTPUT" != "No local changes to save" ]; then
     POP_STASH="$(git stash pop)"
@@ -262,6 +262,7 @@ function unstash_changes() {
       exit 9
     fi
   fi
+  cd $WORKING_DIRECTORY
 }
 
 
@@ -280,9 +281,12 @@ function restore_original_state() {
   unstash_changes
 }
 
+#************************************************************************************
 
-#Get Current Brach
+# Get Current Branch
 PRIOR_BRANCH=$(git symbolic-ref --short HEAD)
+# Get current working directory
+WORKING_DIRECTORY="$(pwd)"
 
 while [ $# -ne 0 ]
 do
@@ -319,6 +323,7 @@ if [ $? != 0 ]; then
   echo "$STASH_OUTPUT"
   exit 1
 fi
+cd $(git rev-parse --show-toplevel)
 
 
 status=1

--- a/git-secure-pull
+++ b/git-secure-pull
@@ -251,7 +251,6 @@ function rsl_verify {
 
 }
 
-#************************************************************************************
 function unstash_changes() {
   if [ "$STASH_OUTPUT" != "No local changes to save" ]; then
     POP_STASH="$(git stash pop)"
@@ -276,12 +275,16 @@ function restore_original_state() {
     echo "$CHECKOUT_ORIGINAL_OUTPUT"
           exit 8
   fi
+  cd $WORKING_DIRECTORY
   unstash_changes
 }
 
+#************************************************************************************
 
-#Get Current Branch
+# Get Current Branch
 PRIOR_BRANCH=$(git symbolic-ref --short HEAD)
+# Get current working directory
+WORKING_DIRECTORY=$(pwd)
 
 while [ $# -ne 0 ]
 do
@@ -318,6 +321,7 @@ if [ $? != 0 ]; then
   echo "$STASH_OUTPUT"
   exit 1
 fi
+cd $(git rev-parse --show-toplevel)
 
 
 status=1

--- a/git-secure-push
+++ b/git-secure-push
@@ -312,11 +312,14 @@ function restore_original_state() {
     echo "$CHECKOUT_ORIGINAL_OUTPUT"
           exit 8
   fi
+  cd $WORKING_DIRECTORY
   unstash_changes
 }
 
 
 #************************************************************************************
+
+WORKING_DIRECTORY=$(pwd)
 PRIOR_BRANCH="$(git symbolic-ref --short HEAD 2>&1)"
 if [[ $? != 0 ]]; then
 	PRIOR_BRANCH="$(git rev-parse HEAD)"
@@ -376,6 +379,7 @@ if [ $? != 0 ]; then
   echo "$STASH_OUTPUT"
   exit 1
 fi
+cd $(git rev-parse --show-toplevel)
 
 
 #Update RSL


### PR DESCRIPTION
This is a stopgap bugfix for the current implementation of secure git commands, which utilizes files to represent the RSL. In order to ore easily manipulate those files, it is simplest to save the initial working directory along with the other initial state, do work in the project root, and return to the initial dir upon completion.